### PR TITLE
Add missing comma to `tags` section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "istext",
     "is text",
     "isbinary",
-    "is binary"
+    "is binary",
     "is text or binary",
     "is text or binary file",
     "isbinaryfile",


### PR DESCRIPTION
At the time of submission for this pull request, the `bevry/istextorbinary` repository currently has a broken `package.json` ([latest commit](https://github.com/bevry/istextorbinary/commit/0f48feba7808ab5f5ec0878149fc95391476079e)).

This causes the following error when running `npm install`:
```
➜  istextorbinary git:(master) npm install
npm ERR! file /istextorbinary/package.json
npm ERR! code EJSONPARSE
npm ERR! Failed to parse json
npm ERR! Unexpected string in JSON at position 359 while parsing '{
npm ERR!   "title": "Is Text or Binary?",
npm ERR!   "na'
npm ERR! File: /istextorbinary/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! A complete log of this run can be found in:
npm ERR!     /.npm/_logs/2017-10-17T20_47_48_970Z-debug.log
```