### PR TITLE
Fix false negatives caused by multibyte utf8 characters.

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -110,7 +110,20 @@ export function getEncoding(
 		return encoding
 	} else {
 		// Extract
-		const chunkEnd = Math.min(buffer.length, chunkBegin + chunkLength)
+		chunkBegin = getChunkBegin(buffer, chunkBegin)
+		if (chunkBegin === -1) {
+			return binaryEncoding
+		}
+
+		const chunkEnd = getChunkEnd(
+			buffer,
+			Math.min(buffer.length, chunkBegin + chunkLength)
+		)
+
+		if (chunkEnd > buffer.length) {
+			return binaryEncoding
+		}
+
 		const contentChunkUTF8 = buffer.toString(textEncoding, chunkBegin, chunkEnd)
 
 		// Detect encoding
@@ -127,4 +140,118 @@ export function getEncoding(
 		// Return
 		return textEncoding
 	}
+}
+
+// The functions below are created to handle multibyte utf8 characters.
+// To understand how the encoding works,
+// check this article: https://en.wikipedia.org/wiki/UTF-8#Encoding
+
+function getChunkBegin(buf: Buffer, chunkBegin: number) {
+	// If it's the beginning, just return.
+	if (chunkBegin === 0) {
+		return 0
+	}
+
+	if (!isLaterByteOfUtf8(buf[chunkBegin])) {
+		return chunkBegin
+	}
+
+	let begin = chunkBegin - 3
+
+	if (begin >= 0) {
+		if (isFirstByteOf4ByteChar(buf[begin])) {
+			return begin
+		}
+	}
+
+	begin = chunkBegin - 2
+
+	if (begin >= 0) {
+		if (
+			isFirstByteOf4ByteChar(buf[begin]) ||
+			isFirstByteOf3ByteChar(buf[begin])
+		) {
+			return begin
+		}
+	}
+
+	begin = chunkBegin - 1
+
+	if (begin >= 0) {
+		// Is it a 4-byte, 3-byte utf8 character?
+		if (
+			isFirstByteOf4ByteChar(buf[begin]) ||
+			isFirstByteOf3ByteChar(buf[begin]) ||
+			isFirstByteOf2ByteChar(buf[begin])
+		) {
+			return begin
+		}
+	}
+
+	return -1
+}
+
+function getChunkEnd(buf: Buffer, chunkEnd: number) {
+	// If it's the end, just return.
+	if (chunkEnd === buf.length) {
+		return chunkEnd
+	}
+
+	let index = chunkEnd - 3
+
+	if (index >= 0) {
+		if (isFirstByteOf4ByteChar(buf[index])) {
+			return chunkEnd + 1
+		}
+	}
+
+	index = chunkEnd - 2
+
+	if (index >= 0) {
+		if (isFirstByteOf4ByteChar(buf[index])) {
+			return chunkEnd + 2
+		}
+
+		if (isFirstByteOf3ByteChar(buf[index])) {
+			return chunkEnd + 1
+		}
+	}
+
+	index = chunkEnd - 1
+
+	if (index >= 0) {
+		if (isFirstByteOf4ByteChar(buf[index])) {
+			return chunkEnd + 3
+		}
+
+		if (isFirstByteOf3ByteChar(buf[index])) {
+			return chunkEnd + 2
+		}
+
+		if (isFirstByteOf2ByteChar(buf[index])) {
+			return chunkEnd + 1
+		}
+	}
+
+	return chunkEnd
+}
+
+function isFirstByteOf4ByteChar(byte: number) {
+	// eslint-disable-next-line no-bitwise
+	return byte >> 3 === 30 // 11110xxx?
+}
+
+function isFirstByteOf3ByteChar(byte: number) {
+	// eslint-disable-next-line no-bitwise
+	return byte >> 4 === 14 // 1110xxxx?
+}
+
+function isFirstByteOf2ByteChar(byte: number) {
+	// eslint-disable-next-line no-bitwise
+	return byte >> 5 === 6 // 110xxxxx?
+}
+
+function isLaterByteOfUtf8(byte: number) {
+	// eslint-disable-next-line no-bitwise
+	return byte >> 6 === 2 // 10xxxxxx?
 }

--- a/source/test.ts
+++ b/source/test.ts
@@ -30,7 +30,7 @@ const tests = [
 		filename: join(fixturesPath, 'issue9.wxml'),
 		text: true,
 		binary: false,
-		encoding: 'binary', // fails encoding detection
+		encoding: 'utf8',
 	},
 	{
 		filename: join(fixturesPath, 'jpg_disguised_as.txt'),
@@ -76,6 +76,29 @@ const tests = [
 	},
 ]
 
+const multibyteUtf8 = [
+	// 1. When there's problem in the chunkEnd
+	// * 2 bytes
+	'12345678901234567890123Ф',
+	// * 3 bytes
+	'12345678901234567890123안',
+	'1234567890123456789012안',
+	// * 4 bytes
+	'12345678901234567890123😀',
+	'1234567890123456789012😀',
+	'123456789012345678901😀',
+	// 2. When there's a problem in the chunkBegin
+	// * 2 bytes
+	'dummyФ12345678901234567890123',
+	// * 3 bytes
+	'dummy안12345678901234567890123',
+	'dummy안1234567890123456789012',
+	// * 4 bytes
+	'dummy😀12345678901234567890123',
+	'dummy😀1234567890123456789012',
+	'dummy😀123456789012345678901',
+]
+
 // Tests
 kava.suite('istextorbinary', function (suite, test) {
 	tests.forEach(function ({ filename, text, binary, encoding }) {
@@ -89,6 +112,12 @@ kava.suite('istextorbinary', function (suite, test) {
 
 			// encoding
 			equal(getEncoding(buffer), encoding, 'getEncoding')
+		})
+	})
+
+	multibyteUtf8.forEach(function (str) {
+		test(str, function () {
+			equal(getEncoding(Buffer.from(str)), 'utf8')
 		})
 	})
 })


### PR DESCRIPTION
Closes #13.

`getEncoding` returns too many false negatives with the strings that contain multibyte characters (Crilly, CJK, Emoji, etc.)

This PR fixes this issue.