### PR TITLE
Update textextensions to 5.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "istextorbinary",
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "binaryextensions": "^4.18.0",
-        "textextensions": "^5.14.0"
+        "textextensions": "^5.16.0"
       },
       "devDependencies": {
         "@bevry/update-contributors": "^1.20.0",
@@ -3464,9 +3465,9 @@
       "dev": true
     },
     "node_modules/textextensions": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.14.0.tgz",
-      "integrity": "sha512-4cAYwNFNYlIAHBUo7p6zw8POUvWbZor+/R0Tanv+rIhsauEyV9QSrEXL40pI+GfTQxKX8k6Tyw6CmdSDSmASrg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.16.0.tgz",
+      "integrity": "sha512-7D/r3s6uPZyU//MCYrX6I14nzauDwJ5CxazouuRGNuvSCihW87ufN6VLoROLCrHg6FblLuJrT6N2BVaPVzqElw==",
       "engines": {
         "node": ">=0.8"
       },
@@ -6338,9 +6339,9 @@
       "dev": true
     },
     "textextensions": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.14.0.tgz",
-      "integrity": "sha512-4cAYwNFNYlIAHBUo7p6zw8POUvWbZor+/R0Tanv+rIhsauEyV9QSrEXL40pI+GfTQxKX8k6Tyw6CmdSDSmASrg=="
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.16.0.tgz",
+      "integrity": "sha512-7D/r3s6uPZyU//MCYrX6I14nzauDwJ5CxazouuRGNuvSCihW87ufN6VLoROLCrHg6FblLuJrT6N2BVaPVzqElw=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
   "module": "edition-browsers/index.js",
   "dependencies": {
     "binaryextensions": "^4.18.0",
-    "textextensions": "^5.14.0"
+    "textextensions": "^5.16.0"
   },
   "devDependencies": {
     "@bevry/update-contributors": "^1.20.0",


### PR DESCRIPTION
textextensions is currently on 5.14.0 which doesn't have Dockerfile, toml, dockerignore or xaml.